### PR TITLE
Ported to Arduino Due platform

### DIFF
--- a/WebServer.h
+++ b/WebServer.h
@@ -127,11 +127,18 @@
 extern "C" unsigned long millis(void);
 
 // declare a static string
+#ifdef __AVR__
 #define P(name)   static const unsigned char name[] PROGMEM
+#else
+#define P(name)   static const unsigned char name[]
+#endif
 
 // returns the number of elements in the array
 #define SIZE(array) (sizeof(array) / sizeof(*array))
 
+#ifdef _VARIANT_ARDUINO_DUE_X_
+#define pgm_read_byte(ptr) (unsigned char)(* ptr)
+#endif
 /********************************************************************
  * DECLARATIONS
  ********************************************************************/


### PR DESCRIPTION
This small patch enables the usage of the Library with the new Arduino ARM-based boards like the Due as noted in issue #37. Changes mainly reflect the change from the Harward-Architecture of the AVR microcontrollers to the Von-Neumann-Architecture of the ARM chips, which makes the separation between program- and data memories obsolete.

I did some testing and everything worked, but this should probably be tested more thoroughly by other people before being merged upstream.
