### PR TITLE
Fix compilation now EthernetClient equality operator is overloaded

### DIFF
--- a/WebServer.h
+++ b/WebServer.h
@@ -350,7 +350,7 @@ private:
 
 WebServer::WebServer(const char *urlPrefix, int port) :
   m_server(port),
-  m_client(255),
+  m_client(MAX_SOCK_NUM),
   m_urlPrefix(urlPrefix),
   m_pushbackDepth(0),
   m_contentLength(0),
@@ -726,7 +726,7 @@ void WebServer::httpSeeOther(const char *otherURL)
 
 int WebServer::read()
 {
-  if (m_client == NULL)
+  if (!m_client)
     return -1;
 
   if (m_pushbackDepth == 0)


### PR DESCRIPTION
Remove comparison of `m_client` against `NULL` as this causes the following compilation error since the addition of an overload for the equality operator in arduino/Arduino@ca37de4ba4ecbdb941f14ac1fe7dd40f3008af75:

```
Webduino/WebServer.h: In member function 'int WebServer::read()':
Webduino/WebServer.h:729: error: ambiguous overload for 'operator==' in '((WebServer*)this)->WebServer::m_client == 0'
Webduino/WebServer.h:729: note: candidates are: operator==(int, int) <built-in>
libraries\Ethernet\src/EthernetClient.h:27: note:                 virtual bool EthernetClient::operator==(const EthernetClient&)
```

This also initializes `m_client` with `MAX_SOCK_NUMBER` instead of `255` to make the boolean test of `m_client` work correctly.
