### PR TITLE
Added support for ENC28J60 chips via ntruchsess' arduino_uip library

### DIFF
--- a/WebServer.h
+++ b/WebServer.h
@@ -28,15 +28,22 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <EthernetClient.h>
-#include <EthernetServer.h>
+
+#ifdef UIPETHERNET_H
+#   include <UIPClient.h>
+#   include <UIPServer.h>
+#   define MAX_SOCK_NUM 255
+#else
+#   include <EthernetClient.h>
+#   include <EthernetServer.h>
+#endif
 
 /********************************************************************
  * CONFIGURATION
  ********************************************************************/
 
 #define WEBDUINO_VERSION 1007
-#define WEBDUINO_VERSION_STRING "1.7"
+#define WEBDUINO_VERSION_STRING "1.7.1"
 
 #if WEBDUINO_SUPRESS_SERVER_HEADER
 #define WEBDUINO_SERVER_HEADER ""
@@ -397,7 +404,12 @@ size_t WebServer::write(uint8_t ch)
 
 size_t WebServer::write(const char *str)
 {
+#ifdef UIPETHERNET_H
+  return m_client.write((const uint8_t *)str, sizeof(str)); 
+#else
   return m_client.write(str);
+#endif
+  
 }
 
 size_t WebServer::write(const uint8_t *buffer, size_t size)

--- a/examples/Web_HelloWorld/Web_HelloWorld.ino
+++ b/examples/Web_HelloWorld/Web_HelloWorld.ino
@@ -1,7 +1,15 @@
 /* Web_HelloWorld.pde - very simple Webduino example */
 
 #include "SPI.h"
+/* If you have a Microchip ENC28J60-based Ethernet shield, 
+ * you can use arduino_uip library at https://github.com/ntruchsess/arduino_uip
+ * and replace the line below with:
+ * 
+ *     #include "UIPEthernet.h"
+ *
+ */
 #include "Ethernet.h"
+
 #include "WebServer.h"
 
 /* CHANGE THIS TO YOUR OWN UNIQUE VALUE.  The MAC number should be

--- a/readme.md
+++ b/readme.md
@@ -36,10 +36,12 @@ These have all been tested with the library successfully:
 - [Adafruit Ethernet Shield w/ Wiznet 811MJ module](http://www.ladyada.net/make/eshield/)
 - [NKC Electronics Ethernet Shield DIY Kit](http://store.nkcelectronics.com/nkc-ethernet-shield-diy-kit-without-wiz812mj-mod812.html)
 
-Shields using the Microchip ENC28J60 chip won't work with the library as that requires more software support for implementating 
-the TCP/IP stack.
+Shields using the Microchip ENC28J60 chip can use ntruchsess' arduino_uip library (https://github.com/ntruchsess/arduino_uip) as a drop-in replacement for the stock Arduino Ethernet library. Take note that since the TCP/IP stack is implemented in software, the compiled sketch size will significantly increase. As a result, if you use an ENC28J60-based shield, your Arduino should have, at the very least, an ATMega328 chip.
 
 ## Version history
+
+### 1.7.1 released Jan 2013
+- added support for ENC28J60 chips via ntruchsess' arduino_uip library.
 
 ### 1.7 released in Jan 2012
 


### PR DESCRIPTION
Added support for ENC28J60-based Ethernet Shields using [ntruchsess' arduino_uip library](https://github.com/ntruchsess/arduino_uip). I have only tested this with [e-Gizmo Ethernet Shield](http://www.e-gizmo.com/KIT/ethernet%20shield.html) since this is the only shield available locally in our country.
