### PR TITLE
constructor m_client(MAX_SOCK_NUM) is not portable (fails to compile with UIPEthernet)

### DIFF
--- a/WebServer.h
+++ b/WebServer.h
@@ -367,7 +367,7 @@ private:
 
 WebServer::WebServer(const char *urlPrefix, int port) :
   m_server(port),
-  m_client(MAX_SOCK_NUM),
+  m_client(),
   m_urlPrefix(urlPrefix),
   m_pushbackDepth(0),
   m_contentLength(0),


### PR DESCRIPTION
the use of constructor EthernetClient(MAX_SOCK_NUM) breaks the compile when being used with UIPEthernet. Using the no-arg constructor has the same effect with Ethernet-library as it initializes _sock to MAX_SOCK_NUM anyway (https://github.com/arduino/Arduino/blob/master/libraries/Ethernet/EthernetClient.cpp#L17)
