### PR TITLE
Fix compiler warnings about narrowing conversion

### DIFF
--- a/WebServer.h
+++ b/WebServer.h
@@ -992,7 +992,7 @@ bool WebServer::readPOSTparam(char *name, int nameLen,
       int ch2 = read();
       if (ch1 == -1 || ch2 == -1)
         return false;
-      char hex[3] = { ch1, ch2, 0 };
+      char hex[3] = { (char)ch1, (char)ch2, '\0' };
       ch = strtoul(hex, NULL, 16);
     }
 


### PR DESCRIPTION
The latest 1.5.7 beta release of Arduino includes an updated toolchain which now issues warnings about narrowing of ints to chars inside curly braces becoming ill-formed in C++11 if warnings are enabled.

For example:

```
Webduino/WebServer.h:995:35: warning: narrowing conversion of 'ch1' from 'int' to 'char' inside { } is ill-formed in C++11 [-Wnarrowing]
```

The commit below explicitly casts the values to char to prevent these warnings being emitted.
